### PR TITLE
RFC for backend alpha v1.0 

### DIFF
--- a/controller/events.go
+++ b/controller/events.go
@@ -79,22 +79,6 @@ func CreateEventHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-//func Secret(w http.ResponseWriter, r *http.Request) {
-//	session, _ := store.Get(r, "auth-session")
-//
-//	// Check if user is authenticated
-//	if auth, ok := session.Values["authenticated"].(bool); !ok || !auth {
-//		http.Error(w, "Forbidden", http.StatusForbidden)
-//		return
-//	}
-//
-//	// Print secret message
-//	_, err := fmt.Fprintln(w, "flag{you_logged_in}")
-//	if err != nil {
-//		panic(err)
-//	}
-//}
-
 func GetAllEventsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Methods", "GET")
@@ -138,9 +122,18 @@ func GetOneEventHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Methods", "GET")
 
+	type Response struct {
+		Success bool             `json:"success"`
+		Events  models.EventInfo `json:"events"`
+	}
+
 	params := mux.Vars(r)
 	event := handler.GetOneEvent(params["id"])
-	err := json.NewEncoder(w).Encode(event)
+	response := Response{
+		Success: true,
+		Events:  event,
+	}
+	err := json.NewEncoder(w).Encode(response)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -150,9 +143,18 @@ func GetUserEventHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Methods", "GET")
 
+	type Response struct {
+		Success bool          `json:"success"`
+		Events  []primitive.M `json:"events"`
+	}
+
 	params := mux.Vars(r)
 	events := handler.GetUserEvents(params["id"])
-	err := json.NewEncoder(w).Encode(events)
+	response := Response{
+		Success: true,
+		Events:  events,
+	}
+	err := json.NewEncoder(w).Encode(response)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -166,10 +168,17 @@ func UpdateEventHandler(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewDecoder(r.Body).Decode(&event)
 	params := mux.Vars(r)
 	err := handler.UpdateEvent(params["id"], event)
+
+	response := models.Response{}
+	response.Success = true
+	response.Message = "Updated data successfully"
+
 	if err != nil {
+		response.Success = false
+		response.Message = err.Error()
 		log.Println(err)
 	}
-	err = json.NewEncoder(w).Encode("[+] Updated data successfully")
+	err = json.NewEncoder(w).Encode(response)
 	if err != nil {
 		log.Println(err)
 	}
@@ -181,7 +190,12 @@ func DeleteEventHandler(w http.ResponseWriter, r *http.Request) {
 
 	params := mux.Vars(r)
 	handler.DeleteEvent(params["id"])
-	err := json.NewEncoder(w).Encode("[+] Deleted Event Successfully")
+
+	response := models.Response{
+		Success: true,
+		Message: "Deleted Event successfully",
+	}
+	err := json.NewEncoder(w).Encode(response)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/controller/users.go
+++ b/controller/users.go
@@ -93,9 +93,18 @@ func GetUserHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Access-Control-Allow-Methods", "GET")
 
+	type Response struct {
+		Success bool        `json:"success"`
+		User    models.User `json:"user"`
+	}
+
 	params := mux.Vars(r)
 	user := handler.GetUser(params["id"])
-	err := json.NewEncoder(w).Encode(user)
+	response := Response{
+		Success: true,
+		User:    user,
+	}
+	err := json.NewEncoder(w).Encode(response)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -108,10 +117,18 @@ func UpdateUserHandler(w http.ResponseWriter, r *http.Request) {
 	var info models.User
 	_ = json.NewDecoder(r.Body).Decode(&info)
 	err := handler.UpdateUser(params["id"], info)
+
+	response := models.Response{}
+	response.Success = true
+	response.Message = "Updated data successfully"
+
 	if err != nil {
+		response.Success = false
+		response.Message = err.Error()
 		log.Println(err)
 	}
-	err = json.NewEncoder(w).Encode("[+] Updated data successfully")
+
+	err = json.NewEncoder(w).Encode(response)
 	if err != nil {
 		log.Println(err)
 	}

--- a/handler/events.go
+++ b/handler/events.go
@@ -34,7 +34,6 @@ func init() {
 }
 
 func fetchUserIDFromEmail(email string) (primitive.ObjectID, error) {
-	// Replace with your MongoDB collection and query
 	var user models.User
 	err := usersCollection.FindOne(context.TODO(), bson.M{"email": email}).Decode(&user)
 	if err != nil {
@@ -43,6 +42,17 @@ func fetchUserIDFromEmail(email string) (primitive.ObjectID, error) {
 	return user.Id, nil
 }
 
+func FetchUserNameFromEmail(email string) (string, error) {
+	var user models.User
+	err := usersCollection.FindOne(context.TODO(), bson.M{"email": email}).Decode(&user)
+	if err != nil {
+		return "", errors.New("user not found")
+	}
+	return user.Name, nil
+}
+
+// TODO: check for event already exists
+
 func InsertEvent(event models.EventInfo, userEmail string) (interface{}, error) {
 	// fetch userid from email
 	userID, err := fetchUserIDFromEmail(userEmail)
@@ -50,8 +60,14 @@ func InsertEvent(event models.EventInfo, userEmail string) (interface{}, error) 
 		return nil, err
 	}
 
+	userName, err := FetchUserNameFromEmail(userEmail)
+	if err != nil {
+		return nil, err
+	}
+
 	event.EventId = primitive.NewObjectID()
-	event.AddedBy = userID
+	event.AddedByID = userID
+	event.AddedByName = userName
 	insertOne, err := eventsCollection.InsertOne(context.TODO(), event)
 	if err != nil {
 		panic(err)

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-func verifyToken(tokenString string) (*jwt.Token, error) {
+func VerifyToken(tokenString string) (*jwt.Token, error) {
 	signingKey := []byte(os.Getenv("KEY"))
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -31,7 +31,7 @@ func JWTmiddleware(next http.Handler) http.Handler {
 		}
 
 		tokenString := strings.TrimPrefix(authHeader, "Bearer ")
-		token, err := verifyToken(tokenString)
+		token, err := VerifyToken(tokenString)
 		if err != nil || !token.Valid {
 			http.Error(w, "Invalid token", http.StatusUnauthorized)
 			return

--- a/models/models.go
+++ b/models/models.go
@@ -15,13 +15,15 @@ type User struct {
 
 type EventInfo struct {
 	EventId     primitive.ObjectID `json:"event_id,omitempty" bson:"_id,omitempty"`
-	EventName   string             `json:"event_name" bson:"event_name"`
+	EventName   string             `json:"event_name" bson:"event_name" validate:"required"`
 	StartDate   string             `json:"start_date" bson:"start_date"`
 	EndDate     string             `json:"end_date" bson:"end_date"`
 	Description string             `json:"description" bson:"description"`
 	EventType   string             `json:"event_type" bson:"event_type"`
+	EventLink   string             `json:"eventLink" bson:"eventLink" validate:"required"`
 	Company     string             `json:"company" bson:"company"`
-	AddedBy     primitive.ObjectID `json:"added_by" bson:"added_by"`
+	AddedByID   primitive.ObjectID `json:"added_by_id" bson:"added_by_id"`
+	AddedByName string             `json:"added_by_name" bson:"added_by_name"`
 }
 
 type Login struct {

--- a/models/models.go
+++ b/models/models.go
@@ -30,3 +30,8 @@ type Login struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
 }
+
+type Response struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}

--- a/models/models.go
+++ b/models/models.go
@@ -7,23 +7,23 @@ import (
 type User struct {
 	Id          primitive.ObjectID `json:"id,omitempty" bson:"_id"`
 	Name        string             `json:"name" bson:"name"`
-	PhoneNumber string             `json:"phone_number" bson:"phone_number"`
+	PhoneNumber string             `json:"phoneNumber" bson:"phoneNumber"`
 	Email       string             `json:"email" bson:"email"`
 	Password    string             `json:"password" bson:"password"`
 	Company     string             `json:"company" bson:"company"`
 }
 
 type EventInfo struct {
-	EventId     primitive.ObjectID `json:"event_id,omitempty" bson:"_id,omitempty"`
-	EventName   string             `json:"event_name" bson:"event_name" validate:"required"`
-	StartDate   string             `json:"start_date" bson:"start_date"`
-	EndDate     string             `json:"end_date" bson:"end_date"`
+	EventId     primitive.ObjectID `json:"eventID,omitempty" bson:"_id,omitempty"`
+	EventName   string             `json:"eventName" bson:"eventName" validate:"required"`
+	StartDate   string             `json:"startDate" bson:"startDate"`
+	EndDate     string             `json:"endDate" bson:"endDate"`
 	Description string             `json:"description" bson:"description"`
-	EventType   string             `json:"event_type" bson:"event_type"`
+	EventType   string             `json:"eventType" bson:"eventType"`
 	EventLink   string             `json:"eventLink" bson:"eventLink" validate:"required"`
 	Company     string             `json:"company" bson:"company"`
-	AddedByID   primitive.ObjectID `json:"added_by_id" bson:"added_by_id"`
-	AddedByName string             `json:"added_by_name" bson:"added_by_name"`
+	AddedByID   primitive.ObjectID `json:"addedByID" bson:"addedByID"`
+	AddedByName string             `json:"addedByName" bson:"addedByName"`
 }
 
 type Login struct {


### PR DESCRIPTION
Closes #6 
* events: change return response for /api/event/all
   makes the response in standard format of `Success` and `data`.
response includes the username if valid JWT is passed in header
else it just returns all the events along with an empty string in
`name` field.
* events: change EventInfo struct fields
   add `event_link` and `added_by_name` in the struct.
this makes it easy to trackdown the name of event lister.
* models: change the model structure to camelCase
   align to the standard of camelCase for model structs.
* feat: change response of all methods
   followed the JSON response structure of
   ```
   Success: bool,
   Message: string,
   ```